### PR TITLE
fix: ignore remote-tracking branch merge commits

### DIFF
--- a/bin/validate-commits
+++ b/bin/validate-commits
@@ -5,7 +5,7 @@ set -eu
 : ${IGNORE_COMMITS_BEFORE:=}
 
 COMMITLOG="$(git-sv commit-log -r hash -s "$IGNORE_COMMITS_BEFORE")"
-JQQUERY='.[] | select(.message.type==null and (.message.description | test("^Merge (branch|pull request|[^ ]+ into [^ ]+)") | not)) | "\u274c ERROR: Commit "+.hash
+JQQUERY='.[] | select(.message.type==null and (.message.description | test("^Merge ((remote-tracking )?branch|pull request|[^ ]+ into [^ ]+)") | not)) | "\u274c ERROR: Commit "+.hash
 	+" has malformed message:\n\n  "+.message.description+"\n\n"'
 ERRORS="$(echo "$COMMITLOG" | jq -sr "$JQQUERY")"
 


### PR DESCRIPTION
Exclude merge commits from validation that are produced by the command `git merge origin/main`.