### PR TITLE
feat: add option to skip pushing the git tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ inputs:
     description: |
       Create a new commit including the specified files and tag it.
       Multiple files can be separated by whitespace.
+  skip-tag-push:
+    description: |
+      Set this to false to skip pushing the git tag during the release.
+      Disable tag pushing when another tool (e.g. goreleaser) pushes the tag.
+    default: false
   github-release-enabled:
     description: Create GitHub Release
     default: true
@@ -65,4 +70,5 @@ runs:
     GITHUB_RELEASE_LATEST: ${{ inputs.github-release-latest }}
     GITHUB_RELEASE_FILES: ${{ inputs.github-release-files }}
     UPDATE_MAJOR_TAG: ${{ inputs.update-major-tag }}
+    SKIP_TAG_PUSH: ${{ inputs.skip-tag-push }}
     AUTO_RELEASE: ${{ inputs.auto-release }}

--- a/bin/complete-release
+++ b/bin/complete-release
@@ -62,6 +62,7 @@ fi
 if echo "$GIT_TAG" | grep -Eq '^'"$TAG_PREFIX"'([0-9]+)\.([0-9]+)\.([0-9]+)$'; then
 	if [ "$UPDATE_MAJOR_TAG" = true ]; then
 		MAJOR_GIT_TAG="$(echo "$GIT_TAG" | grep -Eo '^'"$TAG_PREFIX"'[0-9]+')"
+		echo "Updating major git tag $MAJOR_GIT_TAG"
 		git tag -a "$MAJOR_GIT_TAG" -m "$MAJOR_GIT_TAG" -f
 		git push origin "$MAJOR_GIT_TAG" --quiet --no-verify -f
 	fi

--- a/bin/prepare-release
+++ b/bin/prepare-release
@@ -37,6 +37,10 @@ elif [ "$RELEASE_BRANCH" = "$BRANCH" -a "$AUTO_RELEASE" = true ]; then
 		GIT_TAG="${TAG_PREFIX}$NXTVER"
 		MSG="$(printf 'chore(release): %s [skip ci]\n\n%s\n' "$NXTVER" "$CHANGELOG")"
 		git tag -a "$GIT_TAG" -m "$MSG"
+
+		if [ "$SKIP_TAG_PUSH" = true ]; then
+			ISPUSHTAG=false
+		fi
 	fi
 else
 	NXTVER="$(printf %s-dev-%s "$NXTVER" "$COMMIT")"


### PR DESCRIPTION
This is for setups where another tool within the release job (e.g. goreleaser) pushes the tag already.